### PR TITLE
Make jarvis notebook friendly

### DIFF
--- a/dev/jarvis_app.py
+++ b/dev/jarvis_app.py
@@ -17,132 +17,15 @@ TASKS_DB_ID = extract_database_id(TASKS_DATABASE)
 # secrets = json.load(secrets_path.open())
 
 def jarvis_app():
-    # 1) connect Notion
-    # 2) connect Telegram
-    # 3) Do something - add task handler
-
-    # 1) connect Notion
-    notion_client = notion.Client(auth=env("JARVIS_NOTION_TOKEN"))
-
-    # 2) connect Telegram
+    from jarvis_lib import NotionClient, notion_decorator, telegram_updater
     import telegram.ext
-    telegram_updater = telegram.ext.Updater(env("JARVIS_TELEGRAM_TOKEN"))
-
-    # 3) add message handler
-
-    class NotionClient:
-        def __init__(self, token):
-            self.client = notion.Client(auth=token)
-
-        # var1 - message text, tags - tags.
-        def add_task(self, name, content, tags):
-            """
-            Example:
-            /add_task New task to cleanup #home sdf #urgent sdf
-
-            [] Clean up kitchen etc #idea
-            [] clean up desk
-            #2hours
-
-            :param text:
-            :param tags:
-            :return:
-            """
-            pars = {"parent": {"database_id": TASKS_DB_ID},
-                    "properties": {
-                        "Name": {
-                            "title": [
-                                {
-                                    "text": {
-                                        "content": name,
-                                    },
-                                },
-                            ],
-                        },
-                    },
-                    }
-            if content:
-                pars["children"] = [
-                    {
-                        "object": "block",
-                        "type": "paragraph",
-                        "paragraph": {
-                            "rich_text": [
-                                {
-                                    "type": "text",
-                                    "text": {
-                                        "content": content,
-                                    },
-                                },
-                            ],
-                        },
-                    },
-                ]
-            self.client.pages.create(**pars)
-
-
-    def parse_command(full_command):
-        """
-        Parse telegram command format for Jarvis
-
-        Examples:
-        1. Simple command example:
-        >>> parse_command('/idea Test jarvis #link Notion Assistant #blue #important')
-        {'command': '/idea', 'text': 'Test jarvis', 'tags': {'link': 'Notion Assistant', 'blue': None, 'important': None}}
-
-        2. Text only
-        >>> parse_command('Just text with tags #link Notion Assistant #blue #important')
-        {'command': None, 'text': 'Just text with tags', 'tags': {'link': 'Notion Assistant', 'blue': None, 'important': None}}
-        """
-        output = {}
-
-        # parse command
-        if full_command.startswith('/'):
-            command, message = full_command.split(None, 1)
-            output['command'] = command.rstrip()
-        else:
-            message = full_command
-            output['command'] = None
-
-        text, *tags = message.split('#')
-
-        # parse text
-        text = text.strip()
-        if '\n' in text.strip():
-            # text with content, for example in
-            # /idea Make tests
-            # So that everything is tested
-            # #Important
-            text, content = text.split('\n', 1)
-            output['name'] = text
-            output['content'] = content
-        else:
-            output['name'] = text
-            output['content'] = None
-
-        # parse tags
-        tags = [[part.rstrip() for part in tag.split(None, 1)] for tag in tags]
-        output['tags'] = dict([(tag + [None] if len(tag) == 1 else tag) for tag in tags])
-
-        return output
-
-    # %%
-    def notion_decorator(func):
-        def new_func(upd, cont):
-            parts = parse_command(upd.message.text)
-            res = func(name=parts['name'], content=parts['content'], tags=parts['tags'])
-            if res:
-                upd.message.reply_text(res)
-
-        return new_func
-
     # %%
     # 4) launch
-    nc = NotionClient(token=env("JARVIS_NOTION_TOKEN"))
+    notion_client = NotionClient(token=env("JARVIS_NOTION_TOKEN"))
 
     dispatcher = telegram_updater.dispatcher
     dispatcher.add_handler(telegram.ext.CommandHandler("add_task",
-                                                       notion_decorator(nc.add_task)))
+                                                       notion_decorator(notion_client.add_task)))
 
     # Start the Bot
     telegram_updater.start_polling()

--- a/dev/jarvis_lib.py
+++ b/dev/jarvis_lib.py
@@ -1,7 +1,7 @@
 """
 Temporary file for misc
 """
-
+import notion_client
 from telegram.ext import Updater
 
 # abstract telegram
@@ -29,3 +29,120 @@ class TelegramBot:
 # Jarvis-specific Notion
 
 # utils
+
+# 1) connect Notion
+# 2) connect Telegram
+# 3) Do something - add task handler
+
+
+# 2) connect Telegram
+import telegram.ext
+telegram_updater = telegram.ext.Updater(env("JARVIS_TELEGRAM_TOKEN"))
+
+# 3) add message handler
+
+class NotionClient:
+    def __init__(self, token):
+        self.client = notion_client.Client(auth=token)
+
+    # var1 - message text, tags - tags.
+    def add_task(self, name, content, tags):
+        """
+        Example:
+        /add_task New task to cleanup #home sdf #urgent sdf
+
+        [] Clean up kitchen etc #idea
+        [] clean up desk
+        #2hours
+
+        :param text:
+        :param tags:
+        :return:
+        """
+        pars = {"parent": {"database_id": TASKS_DB_ID},
+                "properties": {
+                    "Name": {
+                        "title": [
+                            {
+                                "text": {
+                                    "content": name,
+                                },
+                            },
+                        ],
+                    },
+                },
+                }
+        if content:
+            pars["children"] = [
+                {
+                    "object": "block",
+                    "type": "paragraph",
+                    "paragraph": {
+                        "rich_text": [
+                            {
+                                "type": "text",
+                                "text": {
+                                    "content": content,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+        self.client.pages.create(**pars)
+
+
+def parse_command(full_command):
+    """
+    Parse telegram command format for Jarvis
+
+    Examples:
+    1. Simple command example:
+    >>> parse_command('/idea Test jarvis #link Notion Assistant #blue #important')
+    {'command': '/idea', 'text': 'Test jarvis', 'tags': {'link': 'Notion Assistant', 'blue': None, 'important': None}}
+
+    2. Text only
+    >>> parse_command('Just text with tags #link Notion Assistant #blue #important')
+    {'command': None, 'text': 'Just text with tags', 'tags': {'link': 'Notion Assistant', 'blue': None, 'important': None}}
+    """
+    output = {}
+
+    # parse command
+    if full_command.startswith('/'):
+        command, message = full_command.split(None, 1)
+        output['command'] = command.rstrip()
+    else:
+        message = full_command
+        output['command'] = None
+
+    text, *tags = message.split('#')
+
+    # parse text
+    text = text.strip()
+    if '\n' in text.strip():
+        # text with content, for example in
+        # /idea Make tests
+        # So that everything is tested
+        # #Important
+        text, content = text.split('\n', 1)
+        output['name'] = text
+        output['content'] = content
+    else:
+        output['name'] = text
+        output['content'] = None
+
+    # parse tags
+    tags = [[part.rstrip() for part in tag.split(None, 1)] for tag in tags]
+    output['tags'] = dict([(tag + [None] if len(tag) == 1 else tag) for tag in tags])
+
+    return output
+
+# %%
+def notion_decorator(func):
+    def new_func(upd, cont):
+        parts = parse_command(upd.message.text)
+        res = func(name=parts['name'], content=parts['content'], tags=parts['tags'])
+        if res:
+            upd.message.reply_text(res)
+
+    return new_func

--- a/dev/notion_glow.py
+++ b/dev/notion_glow.py
@@ -11,3 +11,17 @@ And core item types
 
     - Working session
 """
+from dev.notion_lib import Notion
+
+
+class GlowNotion(Notion):
+
+    def find_page(self, query, context=None):
+        pass
+        # todo: support shortcuts
+        # todo: narrow search to main item types
+
+        # todo: fancy dynamic heuristics
+            # dynamically expand/narrow search based on # of results
+
+            # request additional info from user via telegram

--- a/dev/notion_lib.py
+++ b/dev/notion_lib.py
@@ -1,0 +1,78 @@
+import logging
+
+import notion_client
+# from typing import Dict
+class Notion: # todo: make a factory, forbid duplication
+    def __init__(self, token):
+        self.client = notion_client.Client(auth=token)
+
+    def get_db(self, id):
+        return NotionDB(id=id, client=self)
+
+    def find_db(self, name):
+        res = self.client.search(query=name)['results']
+        if len(res) != 1:
+            raise RuntimeError(f"Ambiguous search results: {res}")  #todo: format pretty
+        return self.get_db(res[0]['id'])
+
+    def get_page(self, id):
+        return NotionPage(id=id, client=self)
+
+    def find_page(self, name):
+        res = self.client.search(query=name)['results']
+        if len(res) > 1:
+            logging.warning(f"Ambiguous search results: {res}")  #todo: format pretty
+        elif len(res) == 0:
+            raise RuntimeError("No results")
+        return self.get_page(res[0]['id'])
+
+    @property
+    def workspace_name(self):
+        return "lavrovs"  # todo: implement properly
+    # @property
+    # def dbs(self) -> Dict[str, NotionDB]:
+    #     pass
+
+
+    # todo map
+
+    # todo dot-access
+#%%
+from functools import cached_property
+NOTION_LINK_TEMPLATE = "https://www.notion.so/{id}"
+
+class NotionObject:
+    def __init__(self, id, client: Notion):
+        self.id = id
+        self.client = client
+
+    @property
+    def url(self):
+        raise NOTION_LINK_TEMPLATE.format(id=self.id)
+#%%
+
+class NotionDB(NotionObject):
+    # def __init__(self, id, client: Notion):
+    #     self.id = id
+    #     self.client = client
+
+    def add(self, item):
+        # todo: verify item, patch if issues
+        self.client.client.pages.create(parent={"database_id": self.id}, **item)
+
+    @cached_property #todo: refresh cache from time to time?
+    def metadata(self):
+        return self.client.client.databases.retrieve(self.id)
+
+    # todo: summary. Recently edited pages + Big pages
+
+    # todo: suggestions - __dir__, dot-access
+#%%
+class NotionPage(NotionObject):
+    # def __init__(self, id,  client: Notion):
+    #     self.id = id
+    #     self.client = client
+
+    @cached_property #todo: just remove? requests are cheap
+    def metadata(self):
+        return self.client.client.pages.retrieve(self.id)

--- a/notion_assistant/javris/config.py
+++ b/notion_assistant/javris/config.py
@@ -1,0 +1,22 @@
+from defaultenv import env
+
+# Jarvis
+notion_token = env("JARVIS_NOTION_TOKEN")
+db_logs = env("JARVIS_SIMPLE_LOG_TABLE")
+db_structured_logs = env("JARVIS_STUCTURED_LOG_TABLE")
+jarvis_env = env("JARVIS_ENV")  # prod or dev
+
+# Jarvis Input Bot
+telegram_input_token = env("JARVIS_TELEGRAM_INPUT_TOKEN")
+db_todos = env("JARVIS_DB_TODOS")
+db_notes = env("JARVIS_DB_NOTES")
+db_bookmarks = env("JARVIS_DB_BOOKMARKS")
+
+# Jarvis Output Bot
+telegram_token = env("JARVIS_TELEGRAM_TOKEN")
+
+# Simple task Selector
+telegram_sts_token = env("JARVIS_TELEGRAM_STS_TOKEN")
+
+# Simple task repeater
+db_str = env("JARVIS_DB_STR")

--- a/notion_assistant/javris/jarvis.py
+++ b/notion_assistant/javris/jarvis.py
@@ -1,0 +1,28 @@
+# jarvis.py
+from time import sleep
+
+import config
+from notion_assistant.javris.notion_client import NotionClient
+
+
+class Jarvis:
+    registered_plugins = []
+
+    def __init__(self):
+        # connect to Notion
+        self.notion_client = NotionClient(config.notion_token)
+        self.launched = False
+
+    def run(self):
+        for Plugin in self.registered_plugins:
+            plugin = Plugin(self)
+            plugin.run()
+
+        self.launched = True
+        while self.launched:
+            sleep(1)
+
+
+if __name__ == '__main__':
+    jarvis = Jarvis()
+    jarvis.run()

--- a/notion_assistant/javris/jarvis_input_bot.py
+++ b/notion_assistant/javris/jarvis_input_bot.py
@@ -1,0 +1,34 @@
+# example: /task, /idea
+# example: search. e.g. apps: /diary /daily plan etc.
+# auto-cleanup old messages
+
+import config
+from jarvis import Jarvis
+from notion_assistant.javris.telegram_client import TelegramClient
+
+
+class JarvisInputBot:
+    def __init__(self, jarvis):
+        # init config values: telegram token etc.
+
+        self.jarvis = jarvis
+        self.notion_client = jarvis.notion_client
+
+        # init telegram client
+        self.telegram_client = TelegramClient(config.telegram_input_token)
+
+    def run(self):
+        # register telegram handlers
+        # - /task
+        # - /idea
+        # ----
+        # - /diary, daily diary
+        # - /plan, daily plan
+
+        # todo: auto-cleanup old messages / clutter
+
+        # launch telegram bot
+        self.telegram_client.run(blocking=False)
+
+
+Jarvis.registered_plugins.append(JarvisInputBot)

--- a/notion_assistant/javris/jarvis_output_bot.py
+++ b/notion_assistant/javris/jarvis_output_bot.py
@@ -1,0 +1,36 @@
+# jarvis output bot
+
+import config
+from jarvis import Jarvis
+# example: links for quick access relevant at this time of day (e.g. Siri)
+# auto-cleanup all other clutter messages
+from notion_assistant.javris.telegram_client import TelegramClient
+
+
+# example: daily agenda.
+
+
+class JarvisOutputBot:
+    def __init__(self, jarvis):
+        # init config values: telegram token etc.
+
+        self.jarvis = jarvis
+        self.notion_client = jarvis.notion_client
+
+        self.telegram_client = TelegramClient(config.telegram_sts_token)
+
+    def run(self):
+        # register telegram handlers
+        # - none for now. ? Or do 'diary' and other app lookup here instead of input?
+
+        # background processes
+        # - daily agenda
+        # - recommended apps
+
+        # todo: auto-cleanup old messages / clutter
+
+        # launch telegram bot
+        self.telegram_client.run(blocking=False)
+
+
+Jarvis.registered_plugins.append(JarvisOutputBot)

--- a/notion_assistant/javris/jarvis_simple_task_selector_bot.py
+++ b/notion_assistant/javris/jarvis_simple_task_selector_bot.py
@@ -1,0 +1,29 @@
+import config
+from jarvis import Jarvis
+from notion_assistant.javris.telegram_client import TelegramClient
+
+
+class JarvisSimpleTaskSelectorBot:
+    def __init__(self, jarvis):
+        self.jarvis = jarvis
+        self.notion_client = jarvis.notion_client
+
+        self.telegram_client = TelegramClient(config.telegram_sts_token)
+
+    def run(self):
+        # register telegram handlers
+        # todo: find notebook - http://localhost:8888/notebooks/notion_assistant/dev/Simple%20task%20selector.ipynb
+        # - start: do what is necessary to init: 1) fix notion db. check it's valid 2) select first task
+        # commands:
+        # - done
+        # - skip
+        # - blocked
+        # - cleanup - get a db view to manually adjust statuses/priorities.
+
+        # todo: auto-cleanup old messages / clutter
+
+        # launch telegram bot
+        self.telegram_client.run(blocking=False)
+
+
+Jarvis.registered_plugins.append(JarvisSimpleTaskSelectorBot)

--- a/notion_assistant/javris/notion_client.py
+++ b/notion_assistant/javris/notion_client.py
@@ -1,0 +1,3 @@
+from dev.notion_lib import Notion
+
+NotionClient = Notion

--- a/notion_assistant/javris/telegram_client.py
+++ b/notion_assistant/javris/telegram_client.py
@@ -1,0 +1,22 @@
+import telegram.ext
+
+
+class TelegramClient:
+    def __init__(self, token):
+        #         self.token = token
+        self.updater = telegram.ext.Updater(token)
+        self.dispatcher = self.updater.dispatcher
+
+    def add_handler(self, command, func):
+        handler = telegram.ext.CommandHandler(command, func)
+        self.dispatcher.add_handler(handler)
+
+    def run(self, blocking: bool):
+        # Start the Bot
+        self.updater.start_polling()
+
+        if blocking:
+            # Run the bot until you press Ctrl-C or the process receives SIGINT,
+            # SIGTERM or SIGABRT. This should be used most of the time, since
+            # start_polling() is non-blocking and will stop the bot gracefully.
+            self.updater.idle()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot
 requests
 git+https://github.com/ramnes/notion-sdk-py@main#egg=notion_client
 git+https://github.com/calmquant/calmlib@master#egg=calmlib
+git+https://github.com/bobuk/defaultenv@master#egg=defaultenv

--- a/scratch/notebooks/Jarvis_3.ipynb
+++ b/scratch/notebooks/Jarvis_3.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Notion Page: https://www.notion.so/lavrovs/Generators-and-tags-design-98ad55d8aae2404bbb20e47da51dfbe6"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "from dev.notion_lib import Notion, NotionDB, NotionPage\n",
+    "from notion_db_enums.db_anchor_enums import C_Type\n",
+    "from scratch.parse_command import jarvis_command_parser\n",
+    "from scratch.parse_command.jarvis_telegram_message_parser import notion_decorator"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# desired usage\n",
+    "\n",
+    "\n",
+    "def generator(target_db_id): #decorator marking a Jarvis command output of which is supposed to be a new\n",
+    "    def decorator(func):\n",
+    "    raise NotImplemented()\n",
+    "    def wrapper(text, content, tags):\n",
+    "        raise NotImplemented()\n",
+    "    for tag in tags:\n",
+    "        # process corre\n",
+    "        raise NotImplemented(\"Process corresponding tags - apply the effects to the generated page\")\n",
+    "        pass\n",
+    "    notion_client.add(db=target_db_id) # adds page to specified db\n",
+    "    return wrapper\n",
+    "\n",
+    "class Jarvis:\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        # todo\n",
+    "        pass\n",
+    "\n",
+    "    @generator(notion_db_id)\n",
+    "    def task\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [
+    {
+     "ename": "IndentationError",
+     "evalue": "expected an indented block (3232417384.py, line 19)",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;36m  File \u001B[0;32m\"/var/folders/fk/k694k5yn3gv3kpgkrt2ftkyc0000gn/T/ipykernel_51932/3232417384.py\"\u001B[0;36m, line \u001B[0;32m19\u001B[0m\n\u001B[0;31m    def tag_source(item, )\u001B[0m\n\u001B[0m      ^\u001B[0m\n\u001B[0;31mIndentationError\u001B[0m\u001B[0;31m:\u001B[0m expected an indented block\n"
+     ]
+    }
+   ],
+   "source": [
+    "# supported tag registry\n",
+    "\n",
+    "# idea: have a list of tags that do something to a page.\n",
+    "# e.g.\n",
+    "\n",
+    "\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# supported generators registry\n",
+    "\n",
+    "# todo: add. generic add\n",
+    "# todo: all the\n",
+    "def compose_block(content):\n",
+    "    return {\n",
+    "            \"object\": 'block',\n",
+    "            \"type\": 'paragraph',\n",
+    "            \"paragraph\": {\n",
+    "                \"rich_text\": [\n",
+    "                    {\n",
+    "                        \"type\": 'text',\n",
+    "                        \"text\": {\n",
+    "                            \"content\": content,\n",
+    "                        },\n",
+    "                    },\n",
+    "                ],\n",
+    "            },\n",
+    "        }\n",
+    "\n",
+    "def compose_item(name, content = None):\n",
+    "    item = {'properties': ({\n",
+    "                               \"Name\": {\n",
+    "                                   \"title\": [\n",
+    "                                       {\n",
+    "                                           \"text\": {\n",
+    "                                               \"content\": name,\n",
+    "                                           },\n",
+    "                                       },\n",
+    "                                   ],\n",
+    "                               },\n",
+    "                           },)}\n",
+    "    if content:\n",
+    "        item['children']=[compose_block(line) for line in content.split('\\n')]\n",
+    "    return item"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from typing import List, Optional\n",
+    "import telegram.ext\n",
+    "def generator(commands: List[str]):\n",
+    "    def wrapper(func):\n",
+    "        # add func to registry\n",
+    "        for command in commands:\n",
+    "            Jarvis.generator_commands[command] = func.__name__\n",
+    "        return func\n",
+    "    return wrapper\n",
+    "\n",
+    "\n",
+    "def tag_processor(commands):\n",
+    "    def wrapper(func):\n",
+    "        # add func to registry\n",
+    "        for command in commands:\n",
+    "            Jarvis.tag_processors[command] = func\n",
+    "        return func\n",
+    "    return wrapper\n",
+    "\n",
+    "@tag_processor([\"tag\"])\n",
+    "def tag_metadata(item, value, column=None):\n",
+    "\n",
+    "\n",
+    "class Jarvis:\n",
+    "    generator_commands = dict()\n",
+    "    tag_processors = dict()\n",
+    "\n",
+    "    def __init__(self, notion_token, telegram_token, telegram_input_token,\n",
+    "                 db_todos, db_notes, db_bookmarks, db_logs, db_structured_logs, db_str, jarvis_env):\n",
+    "        self.nc = Notion(token=notion_token)\n",
+    "        self.telegram_token = telegram_token\n",
+    "        self.telegram_input_token = telegram_input_token\n",
+    "        # ---\n",
+    "        self.db_todos = self.nc.get_db(db_todos)\n",
+    "        self.db_notes = self.nc.get_db(db_notes)\n",
+    "        self.db_bookmarks = self.nc.get_db(db_bookmarks)\n",
+    "        self.db_logs = self.nc.get_db(db_logs)\n",
+    "        self.db_structured_logs = self.nc.get_db(db_structured_logs)\n",
+    "        self.db_str = self.nc.get_db(db_str)\n",
+    "        # --\n",
+    "        self.jarvis_env = jarvis_env\n",
+    "\n",
+    "    @generator(commands=['add'])\n",
+    "    def add_item(self, name, tags, content=None,target_db: Optional[NotionDB]=None, core_type:Optional[C_Type]=None):\n",
+    "        # compose item\n",
+    "        item = compose_item(name=name, content=content)\n",
+    "        # todo: apply tags\n",
+    "        for tag in tags:\n",
+    "            if tag not in Jarvis.tag_processors:\n",
+    "                # raise RuntimeError(f\"Unsupported tag: {tag}\")\n",
+    "                logging.warning(f\"Unsupported tag: {tag}\", conxtex=)\n",
+    "                continue\n",
+    "                # todo: catch errors outside and add logging\n",
+    "            # check\n",
+    "\n",
+    "        if target_db is None:\n",
+    "            # todo: mark page as untagged - for future processing\n",
+    "            target_db = self.db_todos\n",
+    "        target_db.add(item)\n",
+    "        # todo: add logging\n",
+    "        return # reply to the user.\n",
+    "\n",
+    "    @generator(['todo','task'])\n",
+    "    def add_task(self, name, tags: dict, content=None):\n",
+    "        return self.add_item(name=name, tags=tags,content=content,target_db=self.db_todos,core_type=C_Type.Todo)\n",
+    "\n",
+    "    @generator(['idea'])\n",
+    "    def add_idea(self, name, tags: dict, content=None):\n",
+    "        return self.add_item(name=name, tags=tags,content=content,target_db=self.db_todos,core_type=C_Type.Idea)\n",
+    "\n",
+    "\n",
+    "    # ----------------------\n",
+    "    # Tags\n",
+    "\n",
+    "    @tag_processor(['link','expose_to'])\n",
+    "    def tag_link(self, item, query):\n",
+    "        #todo: find page. what db? notion client\n",
+    "\n",
+    "        # add metadata\n",
+    "        #\n",
+    "\n",
+    "    @tag_processor(['who','source'])\n",
+    "    def tag_source(self, item, query):\n",
+    "        # find a person\n",
+    "\n",
+    "\n",
+    "    def run(self):\n",
+    "        jarvis_output = telegram.ext.Updater(self.telegram_token)\n",
+    "        jarvis_input = telegram.ext.Updater(self.telegram_input_token)\n",
+    "\n",
+    "        # wire everything up\n",
+    "        for generator_command, func_name in Jarvis.generator_commands.items():\n",
+    "            func = self.__getattribute__(func_name)\n",
+    "            func = notion_decorator(func) #todo: rename to parse_telegram_command_decorator @akudrinskiy\n",
+    "            handler = telegram.ext.CommandHandler(generator_command, func)\n",
+    "            jarvis_input.dispatcher.add_handler(handler)\n",
+    "\n",
+    "        raise NotImplemented()\n",
+    "\n",
+    "        # connect to telegram\n",
+    "        # register handlers"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from defaultenv import env\n",
+    "jarvis = Jarvis(\n",
+    "    notion_token=env(\"JARVIS_NOTION_TOKEN\"),\n",
+    "    telegram_token=env(\"JARVIS_TELEGRAM_TOKEN\"),\n",
+    "    telegram_input_token=env(\"JARVIS_TELEGRAM_INPUT_TOKEN\"),\n",
+    "    db_todos=env(\"JARVIS_DB_TODOS\"),\n",
+    "    db_notes=env(\"JARVIS_DB_NOTES\"),\n",
+    "    db_bookmarks=env(\"JARVIS_DB_BOOKMARKS\"),\n",
+    "    db_logs=env(\"JARVIS_SIMPLE_LOG_TABLE\"),\n",
+    "    db_structured_logs=env(\"JARVIS_STUCTURED_LOG_TABLE\"),\n",
+    "    db_str=env(\"JARVIS_NOTION_TOKEN\"),\n",
+    "    jarvis_env=env(\"JARVIS_ENV\")\n",
+    "\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "atr\n",
+      "atr\n"
+     ]
+    }
+   ],
+   "source": [
+    "class T:\n",
+    "    def atr(self):\n",
+    "        pass\n",
+    "print(T.atr.__name__)\n",
+    "t = T()\n",
+    "print(t.atr.__name__)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/scratch/notebooks/Scheduled_events.ipynb
+++ b/scratch/notebooks/Scheduled_events.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Notion Page: https://www.notion.so/lavrovs/Scheduling-Simple-Task-Repeater-design-2b0ccebd5e5848049efda8e5e311b7e1"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# inspiration\n",
+    "# schedule lib:\n",
+    "# async (threaded): https://schedule.readthedocs.io/en/stable/parallel-execution.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# notion db id: 21fe98710ebe4d5aaae0e810c28414b5\n",
+    "# DB_str"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import schedule\n",
+    "import time\n",
+    "\n",
+    "def job():\n",
+    "    print(\"I'm working...\")\n",
+    "\n",
+    "schedule.every(10).minutes.do(job)\n",
+    "schedule.every().hour.do(job)\n",
+    "schedule.every().day.at(\"10:30\").do(job)\n",
+    "schedule.every().monday.do(job)\n",
+    "schedule.every().wednesday.at(\"13:15\").do(job)\n",
+    "schedule.every().minute.at(\":17\").do(job)\n",
+    "\n",
+    "while True:\n",
+    "    schedule.run_pending()\n",
+    "    time.sleep(1)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/scratch/notebooks/notion_lib.ipynb
+++ b/scratch/notebooks/notion_lib.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(1)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'dev.notion_lib'",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m                       Traceback (most recent call last)",
+      "\u001B[0;32m/var/folders/fk/k694k5yn3gv3kpgkrt2ftkyc0000gn/T/ipykernel_54155/4026133262.py\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0;32mfrom\u001B[0m \u001B[0mdev\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mnotion_lib\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mNotion\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mNotionDB\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mNotionPage\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      2\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      3\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mnotion_client\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m \u001B[0;31m# from typing import Dict\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      5\u001B[0m \u001B[0;32mclass\u001B[0m \u001B[0mNotion\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0;31m# todo: make a factory, forbid duplication\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m: No module named 'dev.notion_lib'"
+     ]
+    }
+   ],
+   "source": [
+    "from dev.notion_lib import Notion, NotionDB, NotionPage\n",
+    "\n",
+    "import notion_client\n",
+    "# from typing import Dict\n",
+    "class Notion: # todo: make a factory, forbid duplication\n",
+    "    def __init__(self, token):\n",
+    "        self.client = notion_client.Client(auth=token)\n",
+    "\n",
+    "    def get_db(self, db_id):\n",
+    "        return NotionDB(id=db_id, client=self)\n",
+    "\n",
+    "    def find_db(self, name):\n",
+    "        res = self.client.search(query=name)['results']\n",
+    "        if len(res) != 1:\n",
+    "            raise RuntimeError(f\"Ambiguous search results: {res}\")\n",
+    "        return self.get_db(res[0]['id'])\n",
+    "\n",
+    "    @property\n",
+    "    def workspace_name(self):\n",
+    "        return \"lavrovs\" # todo: implement properly\n",
+    "    # @property\n",
+    "    # def dbs(self) -> Dict[str, NotionDB]:\n",
+    "    #     pass\n",
+    "\n",
+    "\n",
+    "    # todo map\n",
+    "\n",
+    "    # todo dot-access"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'cached_property' from 'functools' (/Users/calm/code/anaconda3/envs/dev/lib/python3.7/functools.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mImportError\u001B[0m                               Traceback (most recent call last)",
+      "\u001B[0;32m/var/folders/fk/k694k5yn3gv3kpgkrt2ftkyc0000gn/T/ipykernel_54155/1289311121.py\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0;32mfrom\u001B[0m \u001B[0mfunctools\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mcached_property\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      2\u001B[0m \u001B[0mNOTION_LINK_TEMPLATE\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0;34m\"https://www.notion.so/{id}\"\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      3\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m \u001B[0;32mclass\u001B[0m \u001B[0mNotionObject\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      5\u001B[0m     \u001B[0;32mdef\u001B[0m \u001B[0m__init__\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mself\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mid\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mclient\u001B[0m\u001B[0;34m:\u001B[0m \u001B[0mNotion\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mImportError\u001B[0m: cannot import name 'cached_property' from 'functools' (/Users/calm/code/anaconda3/envs/dev/lib/python3.7/functools.py)"
+     ]
+    }
+   ],
+   "source": [
+    "from functools import cached_property\n",
+    "NOTION_LINK_TEMPLATE = \"https://www.notion.so/{id}\"\n",
+    "\n",
+    "class NotionObject:\n",
+    "    def __init__(self, id, client: Notion):\n",
+    "        self.id = id\n",
+    "        self.client = client\n",
+    "\n",
+    "    @property\n",
+    "    def url(self):\n",
+    "        raise NOTION_LINK_TEMPLATE.format(id=self.id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'NotionObject' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "\u001B[0;32m/var/folders/fk/k694k5yn3gv3kpgkrt2ftkyc0000gn/T/ipykernel_54155/293962988.py\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0;32mclass\u001B[0m \u001B[0mNotionDB\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0mNotionObject\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m:\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      2\u001B[0m     \u001B[0;31m# def __init__(self, id, client: Notion):\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      3\u001B[0m     \u001B[0;31m#     self.id = id\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m     \u001B[0;31m#     self.client = client\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      5\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mNameError\u001B[0m: name 'NotionObject' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "class NotionDB(NotionObject):\n",
+    "    # def __init__(self, id, client: Notion):\n",
+    "    #     self.id = id\n",
+    "    #     self.client = client\n",
+    "\n",
+    "    def add(self, page):\n",
+    "        raise NotImplemented\n",
+    "\n",
+    "    @cached_property #todo: refresh cache from time to time?\n",
+    "    def metadata(self):\n",
+    "        return self.client.client.databases.retrieve(self.id)\n",
+    "\n",
+    "    # todo: summary. Recently edited pages + Big pages\n",
+    "\n",
+    "    # todo: suggestions - __dir__, dot-access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "class NotionPage(NotionObject):\n",
+    "    # def __init__(self, id,  client: Notion):\n",
+    "    #     self.id = id\n",
+    "    #     self.client = client\n",
+    "\n",
+    "    @cached_property #todo: just remove? requests are cheap\n",
+    "    def metadata(self):\n",
+    "        return self.client.client.pages.retrieve(self.id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "# test\n",
+    "from defaultenv import env\n",
+    "n = Notion(env(\"JARVIS_NOTION_TOKEN\"))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'object': 'list',\n 'results': [{'object': 'database',\n   'id': '2290411c-4368-4847-9b48-26e63d740c63',\n   'cover': None,\n   'icon': {'type': 'emoji', 'emoji': '💨'},\n   'created_time': '2022-04-03T15:40:00.000Z',\n   'created_by': {'object': 'user',\n    'id': 'd0643a1e-565f-436c-9f25-e153ed140d34'},\n   'last_edited_by': {'object': 'user',\n    'id': 'd0643a1e-565f-436c-9f25-e153ed140d34'},\n   'last_edited_time': '2022-06-15T16:59:00.000Z',\n   'title': [{'type': 'text',\n     'text': {'content': 'DB_Todos', 'link': None},\n     'annotations': {'bold': False,\n      'italic': False,\n      'strikethrough': False,\n      'underline': False,\n      'code': False,\n      'color': 'default'},\n     'plain_text': 'DB_Todos',\n     'href': None}],\n   'description': [],\n   'properties': {'PM_Context': {'id': '%3DgTh',\n     'name': 'PM_Context',\n     'type': 'relation',\n     'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n      'synced_property_name': 'PM_Context',\n      'synced_property_id': '=gTh'}},\n    'S_Status': {'id': '%3E%7DMG',\n     'name': 'S_Status',\n     'type': 'select',\n     'select': {'options': [{'id': '08225dd6-59b2-4851-85c6-d95a4d5d0dda',\n        'name': 'Cancelled',\n        'color': 'blue'},\n       {'id': '9b478edd-c304-4075-a487-150643b102f3',\n        'name': 'Done',\n        'color': 'red'},\n       {'id': 'bdbf7dc0-1666-442c-b462-3a9931f08e44',\n        'name': 'In progress',\n        'color': 'orange'},\n       {'id': 'ec9a1062-2383-49f4-b5a6-d2bfb5f34256',\n        'name': 'Focus',\n        'color': 'pink'},\n       {'id': '43bfb82c-22a5-4345-9432-c2007a050d23',\n        'name': 'Todo',\n        'color': 'purple'}]}},\n    'C_Date': {'id': 'AZEp', 'name': 'C_Date', 'type': 'date', 'date': {}},\n    'Rel_Original Notes': {'id': 'Bo%7Bu',\n     'name': 'Rel_Original Notes',\n     'type': 'relation',\n     'relation': {'database_id': '8f782a80-888f-4342-b8b9-4e8c52de8f30',\n      'synced_property_name': 'C_Origin',\n      'synced_property_id': '``{F'}},\n    'Rel_Exposed Bookmarks': {'id': 'Di%40f',\n     'name': 'Rel_Exposed Bookmarks',\n     'type': 'relation',\n     'relation': {'database_id': 'bd084192-4989-4714-a10b-6b2051a5d5c4',\n      'synced_property_name': 'C_Expose to',\n      'synced_property_id': 'x{ei'}},\n    'C_Edited': {'id': 'Ghph',\n     'name': 'C_Edited',\n     'type': 'last_edited_time',\n     'last_edited_time': {}},\n    'C_Origin': {'id': 'Gxvs',\n     'name': 'C_Origin',\n     'type': 'relation',\n     'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n      'synced_property_name': 'C_Origin',\n      'synced_property_id': 'Gxvs'}},\n    'Rel_Exposed Notes': {'id': 'MIs%5E',\n     'name': 'Rel_Exposed Notes',\n     'type': 'relation',\n     'relation': {'database_id': '8f782a80-888f-4342-b8b9-4e8c52de8f30',\n      'synced_property_name': 'C_Expose to',\n      'synced_property_id': '{qAR'}},\n    'SC_Sorted_Disposable': {'id': 'Q~%5C%5B',\n     'name': 'SC_Sorted_Disposable',\n     'type': 'checkbox',\n     'checkbox': {}},\n    'C_Archive': {'id': 'V%5DQY',\n     'name': 'C_Archive',\n     'type': 'checkbox',\n     'checkbox': {}},\n    'Rel_Original Bookmarks': {'id': '%60UJZ',\n     'name': 'Rel_Original Bookmarks',\n     'type': 'relation',\n     'relation': {'database_id': 'bd084192-4989-4714-a10b-6b2051a5d5c4',\n      'synced_property_name': 'C_Origin',\n      'synced_property_id': 'l^|r'}},\n    'C_Expose to': {'id': 'aOi_',\n     'name': 'C_Expose to',\n     'type': 'relation',\n     'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n      'synced_property_name': 'C_Expose to',\n      'synced_property_id': 'aOi_'}},\n    'S_Priority': {'id': 'h%3AI%5E',\n     'name': 'S_Priority',\n     'type': 'select',\n     'select': {'options': [{'id': '0c601633-1335-4c1c-9c63-efdacb08ec51',\n        'name': '1 - Lowest',\n        'color': 'red'},\n       {'id': '091e8bb9-b083-4eea-b2f5-88bfd1a5fb27',\n        'name': '2 - Low',\n        'color': 'orange'},\n       {'id': '692a369a-7394-45d2-ab7d-37d5d18cc793',\n        'name': '3 - Medium',\n        'color': 'blue'},\n       {'id': '8a81e86e-4e6d-45da-a32c-af8a3298cae7',\n        'name': '4 - High',\n        'color': 'gray'},\n       {'id': 'ff482b9f-069f-4ec7-8503-e8211fbcf42b',\n        'name': '5 - Highest',\n        'color': 'default'}]}},\n    'C_Subtype': {'id': 'jag%5D',\n     'name': 'C_Subtype',\n     'type': 'select',\n     'select': {'options': [{'id': '9a906874-7aab-4566-a6dd-7a2c7beedafa',\n        'name': 'Area',\n        'color': 'pink'}]}},\n    'C_Created': {'id': 'wCGR',\n     'name': 'C_Created',\n     'type': 'created_time',\n     'created_time': {}},\n    'C_Type': {'id': 'x%60%5DW',\n     'name': 'C_Type',\n     'type': 'select',\n     'select': {'options': [{'id': 'fc\\\\a',\n        'name': 'Disposable',\n        'color': 'yellow'},\n       {'id': '<Usl', 'name': 'Idea', 'color': 'purple'},\n       {'id': '72d2927c-3e6c-48f8-bd6f-787e8c0b6cc6',\n        'name': 'Todo',\n        'color': 'green'},\n       {'id': '14885840-2516-4788-bbd9-03e7c3088117',\n        'name': 'Context/Project',\n        'color': 'pink'},\n       {'id': 'e3273a77-1b6f-4c53-8d26-662b2b629027',\n        'name': 'App/Process',\n        'color': 'gray'}]}},\n    'S_Area': {'id': '%7Dn%5B%3B',\n     'name': 'S_Area',\n     'type': 'select',\n     'select': {'options': [{'id': 'ccc71352-b90e-474a-8807-439528967095',\n        'name': 'Home',\n        'color': 'blue'},\n       {'id': '47bc356a-4748-4c67-846a-d48b04948f48',\n        'name': 'Work',\n        'color': 'brown'},\n       {'id': 'b245394f-74e8-4791-8d5f-4195917b758e',\n        'name': 'Wellbeing',\n        'color': 'pink'},\n       {'id': 'ade4fc2a-b575-4d4d-b575-63c35da255a3',\n        'name': 'For Others',\n        'color': 'green'},\n       {'id': '2434433f-8a18-485a-909d-d8c92a01317d',\n        'name': 'Meta',\n        'color': 'orange'},\n       {'id': '643a745f-8a39-4117-b2fa-ef76eea32798',\n        'name': 'Life',\n        'color': 'yellow'},\n       {'id': 'cbceb019-a686-4d6d-9df9-e7c57f88b125',\n        'name': 'Unclear',\n        'color': 'gray'}]}},\n    'Name': {'id': 'title', 'name': 'Name', 'type': 'title', 'title': {}}},\n   'parent': {'type': 'page_id',\n    'page_id': '2d68097a-396a-4419-a35c-2f98e0eeab12'},\n   'url': 'https://www.notion.so/2290411c436848479b4826e63d740c63',\n   'archived': False}],\n 'next_cursor': None,\n 'has_more': False,\n 'type': 'page_or_database',\n 'page_or_database': {}}"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n.client.search(query=\"DB_todos\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [],
+   "source": [
+    "n.client.search?\n",
+    "https://developers.notion.com/reference/post-search"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'n' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "\u001B[0;32m/var/folders/fk/k694k5yn3gv3kpgkrt2ftkyc0000gn/T/ipykernel_54155/9902742.py\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0mn\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mclient\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mpages\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mretrieve\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;34m\"7dbadc6c39e04ad4ac61b3fc92b60111\"\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m: name 'n' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "n.client.pages.retrieve(\"7dbadc6c39e04ad4ac61b3fc92b60111\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'object': 'database',\n 'id': '2290411c-4368-4847-9b48-26e63d740c63',\n 'cover': None,\n 'icon': {'type': 'emoji', 'emoji': '💨'},\n 'created_time': '2022-04-03T15:40:00.000Z',\n 'created_by': {'object': 'user',\n  'id': 'd0643a1e-565f-436c-9f25-e153ed140d34'},\n 'last_edited_by': {'object': 'user',\n  'id': 'd0643a1e-565f-436c-9f25-e153ed140d34'},\n 'last_edited_time': '2022-06-15T16:59:00.000Z',\n 'title': [{'type': 'text',\n   'text': {'content': 'DB_Todos', 'link': None},\n   'annotations': {'bold': False,\n    'italic': False,\n    'strikethrough': False,\n    'underline': False,\n    'code': False,\n    'color': 'default'},\n   'plain_text': 'DB_Todos',\n   'href': None}],\n 'description': [],\n 'properties': {'PM_Context': {'id': '%3DgTh',\n   'name': 'PM_Context',\n   'type': 'relation',\n   'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n    'synced_property_name': 'PM_Context',\n    'synced_property_id': '=gTh'}},\n  'S_Status': {'id': '%3E%7DMG',\n   'name': 'S_Status',\n   'type': 'select',\n   'select': {'options': [{'id': '08225dd6-59b2-4851-85c6-d95a4d5d0dda',\n      'name': 'Cancelled',\n      'color': 'blue'},\n     {'id': '9b478edd-c304-4075-a487-150643b102f3',\n      'name': 'Done',\n      'color': 'red'},\n     {'id': 'bdbf7dc0-1666-442c-b462-3a9931f08e44',\n      'name': 'In progress',\n      'color': 'orange'},\n     {'id': 'ec9a1062-2383-49f4-b5a6-d2bfb5f34256',\n      'name': 'Focus',\n      'color': 'pink'},\n     {'id': '43bfb82c-22a5-4345-9432-c2007a050d23',\n      'name': 'Todo',\n      'color': 'purple'}]}},\n  'C_Date': {'id': 'AZEp', 'name': 'C_Date', 'type': 'date', 'date': {}},\n  'Rel_Original Notes': {'id': 'Bo%7Bu',\n   'name': 'Rel_Original Notes',\n   'type': 'relation',\n   'relation': {'database_id': '8f782a80-888f-4342-b8b9-4e8c52de8f30',\n    'synced_property_name': 'C_Origin',\n    'synced_property_id': '``{F'}},\n  'Rel_Exposed Bookmarks': {'id': 'Di%40f',\n   'name': 'Rel_Exposed Bookmarks',\n   'type': 'relation',\n   'relation': {'database_id': 'bd084192-4989-4714-a10b-6b2051a5d5c4',\n    'synced_property_name': 'C_Expose to',\n    'synced_property_id': 'x{ei'}},\n  'C_Edited': {'id': 'Ghph',\n   'name': 'C_Edited',\n   'type': 'last_edited_time',\n   'last_edited_time': {}},\n  'C_Origin': {'id': 'Gxvs',\n   'name': 'C_Origin',\n   'type': 'relation',\n   'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n    'synced_property_name': 'C_Origin',\n    'synced_property_id': 'Gxvs'}},\n  'Rel_Exposed Notes': {'id': 'MIs%5E',\n   'name': 'Rel_Exposed Notes',\n   'type': 'relation',\n   'relation': {'database_id': '8f782a80-888f-4342-b8b9-4e8c52de8f30',\n    'synced_property_name': 'C_Expose to',\n    'synced_property_id': '{qAR'}},\n  'SC_Sorted_Disposable': {'id': 'Q~%5C%5B',\n   'name': 'SC_Sorted_Disposable',\n   'type': 'checkbox',\n   'checkbox': {}},\n  'C_Archive': {'id': 'V%5DQY',\n   'name': 'C_Archive',\n   'type': 'checkbox',\n   'checkbox': {}},\n  'Rel_Original Bookmarks': {'id': '%60UJZ',\n   'name': 'Rel_Original Bookmarks',\n   'type': 'relation',\n   'relation': {'database_id': 'bd084192-4989-4714-a10b-6b2051a5d5c4',\n    'synced_property_name': 'C_Origin',\n    'synced_property_id': 'l^|r'}},\n  'C_Expose to': {'id': 'aOi_',\n   'name': 'C_Expose to',\n   'type': 'relation',\n   'relation': {'database_id': '2290411c-4368-4847-9b48-26e63d740c63',\n    'synced_property_name': 'C_Expose to',\n    'synced_property_id': 'aOi_'}},\n  'S_Priority': {'id': 'h%3AI%5E',\n   'name': 'S_Priority',\n   'type': 'select',\n   'select': {'options': [{'id': '0c601633-1335-4c1c-9c63-efdacb08ec51',\n      'name': '1 - Lowest',\n      'color': 'red'},\n     {'id': '091e8bb9-b083-4eea-b2f5-88bfd1a5fb27',\n      'name': '2 - Low',\n      'color': 'orange'},\n     {'id': '692a369a-7394-45d2-ab7d-37d5d18cc793',\n      'name': '3 - Medium',\n      'color': 'blue'},\n     {'id': '8a81e86e-4e6d-45da-a32c-af8a3298cae7',\n      'name': '4 - High',\n      'color': 'gray'},\n     {'id': 'ff482b9f-069f-4ec7-8503-e8211fbcf42b',\n      'name': '5 - Highest',\n      'color': 'default'}]}},\n  'C_Subtype': {'id': 'jag%5D',\n   'name': 'C_Subtype',\n   'type': 'select',\n   'select': {'options': [{'id': '9a906874-7aab-4566-a6dd-7a2c7beedafa',\n      'name': 'Area',\n      'color': 'pink'}]}},\n  'C_Created': {'id': 'wCGR',\n   'name': 'C_Created',\n   'type': 'created_time',\n   'created_time': {}},\n  'C_Type': {'id': 'x%60%5DW',\n   'name': 'C_Type',\n   'type': 'select',\n   'select': {'options': [{'id': 'fc\\\\a',\n      'name': 'Disposable',\n      'color': 'yellow'},\n     {'id': '<Usl', 'name': 'Idea', 'color': 'purple'},\n     {'id': '72d2927c-3e6c-48f8-bd6f-787e8c0b6cc6',\n      'name': 'Todo',\n      'color': 'green'},\n     {'id': '14885840-2516-4788-bbd9-03e7c3088117',\n      'name': 'Context/Project',\n      'color': 'pink'},\n     {'id': 'e3273a77-1b6f-4c53-8d26-662b2b629027',\n      'name': 'App/Process',\n      'color': 'gray'}]}},\n  'S_Area': {'id': '%7Dn%5B%3B',\n   'name': 'S_Area',\n   'type': 'select',\n   'select': {'options': [{'id': 'ccc71352-b90e-474a-8807-439528967095',\n      'name': 'Home',\n      'color': 'blue'},\n     {'id': '47bc356a-4748-4c67-846a-d48b04948f48',\n      'name': 'Work',\n      'color': 'brown'},\n     {'id': 'b245394f-74e8-4791-8d5f-4195917b758e',\n      'name': 'Wellbeing',\n      'color': 'pink'},\n     {'id': 'ade4fc2a-b575-4d4d-b575-63c35da255a3',\n      'name': 'For Others',\n      'color': 'green'},\n     {'id': '2434433f-8a18-485a-909d-d8c92a01317d',\n      'name': 'Meta',\n      'color': 'orange'},\n     {'id': '643a745f-8a39-4117-b2fa-ef76eea32798',\n      'name': 'Life',\n      'color': 'yellow'},\n     {'id': 'cbceb019-a686-4d6d-9df9-e7c57f88b125',\n      'name': 'Unclear',\n      'color': 'gray'}]}},\n  'Name': {'id': 'title', 'name': 'Name', 'type': 'title', 'title': {}}},\n 'parent': {'type': 'page_id',\n  'page_id': '2d68097a-396a-4419-a35c-2f98e0eeab12'},\n 'url': 'https://www.notion.so/2290411c436848479b4826e63d740c63',\n 'archived': False}"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n.client.databases.retrieve(\"2290411c-4368-4847-9b48-26e63d740c63\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Jarvis_3.ipynb

  Notion generators - methods and commands for adding items
    todo, task
    idea
    todo: recommendation
  Notion tags - methods and commands for modifying items metadata
    draft: link, expose_to
    draft: who, source
    draft: generic tag, metadata
    todo: pre-process generator tags (#idea etc) - required for simple text support
    todo: support enums

  class Jarvis:
    init
    generators
    tags
    run

  utils:
    compose_item
    compose_block

notion_lib.py:
  Notion
  NotionDB
  NotionPage
  NotionObject (parent class)

notion_glow.py:
  Add fancy page search draft - to resolve issues with too many pages: filter out archived pages etc.

todo: add required fancies. What's already ready and easy to do:
- reply to user with informative messages (page link)
- help message if there's confusion (list supported commands, docstrings)
- parse simple text messages properly (to be re-used for inline parsing as well)
- proper page search for #link and #who (db_people for #who)

Tech debt:
- Logging!
- Catch errors, don't crash

Essential features to follow-up:
- quick lookup - people
- auto-maps: people, projects, dbs, contexts (recent, big)
- page sorting, info request